### PR TITLE
Added method to check if a hash is an invalid hash

### DIFF
--- a/src/Scrypt/ScryptEncoder.cs
+++ b/src/Scrypt/ScryptEncoder.cs
@@ -116,8 +116,11 @@ namespace Scrypt
             int threadCount;
             byte[] saltBytes;
 
-            ExtractHeader(hashedPassword, out iterationCount, out blockSize, out threadCount, out saltBytes);
-
+            if (!ExtractHeader(hashedPassword, out iterationCount, out blockSize, out threadCount, out saltBytes))
+            {
+                return false;
+            }
+            
             return SafeEquals(Encode(password, saltBytes, iterationCount, blockSize, threadCount), hashedPassword);
         }
 
@@ -165,13 +168,17 @@ namespace Scrypt
         /// <summary>
         /// Extracts header from a hashed password.
         /// </summary>
-        private static void ExtractHeader(string hashedPassword, out int iterationCount, out int blockSize, out int threadCount, out byte[] saltBytes)
+        private static bool ExtractHeader(string hashedPassword, out int iterationCount, out int blockSize, out int threadCount, out byte[] saltBytes)
         {
             var parts = hashedPassword.Split('$');
 
             if (parts.Length != 5 || parts[1] != "s0")
             {
-                throw new ArgumentException("Invalid hashed password", "hashedPassword");
+                iterationCount = -1;
+                blockSize = -1;
+                threadCount = -1;
+                saltBytes = new byte[0];
+                return false;
             }
 
             var config = Convert.ToInt64(parts[2], 16);
@@ -181,6 +188,7 @@ namespace Scrypt
             threadCount = (int)config & 0xff;
 
             saltBytes = Convert.FromBase64String(parts[3]);
+            return true;
         }
 
         /// <summary>

--- a/src/Scrypt/ScryptEncoder.cs
+++ b/src/Scrypt/ScryptEncoder.cs
@@ -116,11 +116,8 @@ namespace Scrypt
             int threadCount;
             byte[] saltBytes;
 
-            if (!ExtractHeader(hashedPassword, out iterationCount, out blockSize, out threadCount, out saltBytes))
-            {
-                return false;
-            }
-            
+            ExtractHeader(hashedPassword, out iterationCount, out blockSize, out threadCount, out saltBytes);
+
             return SafeEquals(Encode(password, saltBytes, iterationCount, blockSize, threadCount), hashedPassword);
         }
 
@@ -168,17 +165,13 @@ namespace Scrypt
         /// <summary>
         /// Extracts header from a hashed password.
         /// </summary>
-        private static bool ExtractHeader(string hashedPassword, out int iterationCount, out int blockSize, out int threadCount, out byte[] saltBytes)
+        private static void ExtractHeader(string hashedPassword, out int iterationCount, out int blockSize, out int threadCount, out byte[] saltBytes)
         {
             var parts = hashedPassword.Split('$');
 
             if (parts.Length != 5 || parts[1] != "s0")
             {
-                iterationCount = -1;
-                blockSize = -1;
-                threadCount = -1;
-                saltBytes = new byte[0];
-                return false;
+                throw new ArgumentException("Invalid hashed password", "hashedPassword");
             }
 
             var config = Convert.ToInt64(parts[2], 16);
@@ -188,7 +181,6 @@ namespace Scrypt
             threadCount = (int)config & 0xff;
 
             saltBytes = Convert.FromBase64String(parts[3]);
-            return true;
         }
 
         /// <summary>

--- a/src/Scrypt/ScryptEncoder.cs
+++ b/src/Scrypt/ScryptEncoder.cs
@@ -139,6 +139,20 @@ namespace Scrypt
         }
 
         /// <summary>
+        /// Checks if the given hash is a valid scrypt hash
+        /// </summary>
+        public bool IsValid(string hashedPassword)
+        {
+            if (string.IsNullOrEmpty(hashedPassword))
+            {
+                return false;
+            }
+
+            var parts = hashedPassword.Split('$');
+            return parts.Length == 5 && parts[1] == "s0";
+        }
+
+        /// <summary>
         /// Hash a password using the scrypt scheme.
         /// </summary>
         private static string Encode(string password, byte[] saltBytes, int iterationCount, int blockSize, int threadCount)
@@ -165,14 +179,14 @@ namespace Scrypt
         /// <summary>
         /// Extracts header from a hashed password.
         /// </summary>
-        private static void ExtractHeader(string hashedPassword, out int iterationCount, out int blockSize, out int threadCount, out byte[] saltBytes)
+        private void ExtractHeader(string hashedPassword, out int iterationCount, out int blockSize, out int threadCount, out byte[] saltBytes)
         {
-            var parts = hashedPassword.Split('$');
-
-            if (parts.Length != 5 || parts[1] != "s0")
+            if (!IsValid(hashedPassword))
             {
                 throw new ArgumentException("Invalid hashed password", "hashedPassword");
             }
+
+            var parts = hashedPassword.Split('$');
 
             var config = Convert.ToInt64(parts[2], 16);
 


### PR DESCRIPTION
I was trying to use your library to compare cleartext against 2 different types of input hashes, and having to handle ArgumentExceptions instead of just returning false feels like a bad design to me.
Hopefully you would agree. 