### PR TITLE
Make CryptoScrypt method public and include keyLength option

### DIFF
--- a/src/Scrypt.Core/Scrypt.Core.csproj
+++ b/src/Scrypt.Core/Scrypt.Core.csproj
@@ -1,31 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Scrypt</AssemblyName>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType></DebugType>
-    <DefineConstants>DEBUG;TRACE;NETSTANDARD$(TargetFrameworkVersion_SubString(1));COREFX</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType></DebugType>
-    <DefineConstants>TRACE;NETSTANDARD$(TargetFrameworkVersion_SubString(1));COREFX</DefineConstants>
+    <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <Compile Include="..\Scrypt\ScryptEncoder.cs">
+    <Compile Include="../Scrypt/ScryptEncoder.cs">
       <Link>ScryptEncoder.cs</Link>
     </Compile>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="1.6" />
-  </ItemGroup>
-
 </Project>

--- a/src/Scrypt/ScryptEncoder.cs
+++ b/src/Scrypt/ScryptEncoder.cs
@@ -178,7 +178,7 @@ namespace Scrypt
                 return false;
             }
 
-            if (version == 2) 
+            if (version == 2)
             {
                 if (parts.Length != 7)
                 {
@@ -210,7 +210,7 @@ namespace Scrypt
                 throw new ArgumentException("iterationCount must be a power of two greater than 1", "iterationCount");
             }
 
-            if ((ulong)r*(ulong)p >= 1<<30 || r > Int32.MaxValue/128/p || r > Int32.MaxValue/256 || N > Int32.MaxValue/128/r)
+            if ((ulong)r * (ulong)p >= 1 << 30 || r > Int32.MaxValue / 128 / p || r > Int32.MaxValue / 256 || N > Int32.MaxValue / 128 / r)
             {
                 throw new ArgumentException("Parameters are too large");
             }
@@ -230,7 +230,7 @@ namespace Scrypt
 
             return sb.ToString();
         }
-        
+
         /// <summary>
         /// Hash a password using the scrypt scheme.
         /// This is a DEPRECATED version.
@@ -304,13 +304,13 @@ namespace Scrypt
             version = parts[1][1] - '0';
 
             if (version >= 2)
-            {                
+            {
                 iterationCount = Convert.ToInt32(parts[2]);
                 blockSize = Convert.ToInt32(parts[3]);
                 threadCount = Convert.ToInt32(parts[4]);
                 saltBytes = Convert.FromBase64String(parts[5]);
             }
-            else 
+            else
             {
                 var config = Convert.ToInt64(parts[2], 16);
                 iterationCount = (int)config >> 16 & 0xffff;
@@ -596,12 +596,12 @@ namespace Scrypt
         /// <summary>
         /// Compute and returns the result.
         /// </summary>
-        private unsafe static byte[] CryptoScrypt(byte[] password, byte[] salt, int N, int r, int p)
+        public unsafe static byte[] CryptoScrypt(byte[] password, byte[] salt, int N, int r, int p, int keyLength = 32)
         {
             var Ba = new byte[128 * r * p + 63];
             var XYa = new byte[256 * r + 63];
             var Va = new byte[128 * r * N + 63];
-            var buf = new byte[32];
+            var buf = new byte[keyLength];
 
             var mac = new HMACSHA256(password);
 


### PR DESCRIPTION
Makes CryptoScrypt method public and includes a keyLength option
Also bumps netstandard to 2.0.

We needed this exposed to get hash compatibility with an existing app of ours.
It's a bit of a shame the Scrypt algorithm isn't exposed at all right now, using reflection on unsafe methods is almost impossible.