### PR TITLE
Test Vectors for scrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ nuget.exe
 #*.csproj
 #*.kproj
 *.lock.json
+.vs/

--- a/Scrypt.sln
+++ b/Scrypt.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34525.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7A73E3DB-F7EF-4F58-8B10-56079BFE0460}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scrypt.Net20", "src\Scrypt.Net20\Scrypt.Net20.csproj", "{F27E95A9-FC05-43D0-9801-00C496B497EA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scrypt.Tests", "src\Scrypt.Tests\Scrypt.Tests.csproj", "{4AB836C3-5041-470C-ABE8-04C475952017}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scrypt.Core", "src\Scrypt.Core\Scrypt.Core.csproj", "{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,18 @@ Global
 		{4AB836C3-5041-470C-ABE8-04C475952017}.Release|x64.Build.0 = Release|Any CPU
 		{4AB836C3-5041-470C-ABE8-04C475952017}.Release|x86.ActiveCfg = Release|Any CPU
 		{4AB836C3-5041-470C-ABE8-04C475952017}.Release|x86.Build.0 = Release|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Debug|x64.Build.0 = Debug|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Debug|x86.Build.0 = Debug|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Release|x64.ActiveCfg = Release|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Release|x64.Build.0 = Release|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Release|x86.ActiveCfg = Release|Any CPU
+		{24286B6A-BE93-463E-A22B-D27AAC1D5CCA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +60,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F27E95A9-FC05-43D0-9801-00C496B497EA} = {7A73E3DB-F7EF-4F58-8B10-56079BFE0460}
 		{4AB836C3-5041-470C-ABE8-04C475952017} = {7A73E3DB-F7EF-4F58-8B10-56079BFE0460}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F4E858E0-3604-41D3-9BDE-8FC7500BC607}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = src\Scrypt\Scrypt.csproj

--- a/src/Scrypt.Tests/Scrypt.Tests.csproj
+++ b/src/Scrypt.Tests/Scrypt.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -12,7 +13,8 @@
     <AssemblyName>Scrypt.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>fcc658d9</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -78,6 +80,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Scrypt.Tests/Scrypt.Tests.csproj
+++ b/src/Scrypt.Tests/Scrypt.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Scrypt.Tests</RootNamespace>
     <AssemblyName>Scrypt.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>fcc658d9</NuGetPackageImportStamp>
     <TargetFrameworkProfile />

--- a/src/Scrypt.Tests/ScryptEncoderTests.cs
+++ b/src/Scrypt.Tests/ScryptEncoderTests.cs
@@ -45,15 +45,13 @@ namespace Scrypt.Tests
             Assert.Throws<ArgumentException>(() => encoder.Encode("MyPassword"));
         }
 
-        [Fact]
-        public void TestBackwardCompatibility()
+        [Theory]
+        [InlineData("$s0$40000801$eM1F+ITBb6SVFQ5QxD2jWXY8s4RGsIU+Yh4JosOewoY=$1h22/MY2cpm9Vz7//NRiXwCjffVXQWOKJ7n27vNVfP4=")]
+        [InlineData("$s1$40000801$5ScyYcGbFmSF5P+A64cThg+c6rFtsfyxDHkWWCt97xI=$U+7EMhBXHjNHudmn/sgvX4VZ6ddoSKLkL0nDOSKYLaQ=")]
+        [InlineData("$s2$16384$8$1$pKHZk7yiyj5l4UaW1lMDBkj6Q0+Fw/Nyqx9r+sgM9PE=$JuhWa5STBbHuPbOJjcxSV8WDxSH5hQsPlW9nTNce/sc=")]
+        public void TestVersionsForBackwardCompatibility(string hashedPassword)
         {
             var encoder = new ScryptEncoder();
-
-            var hashedPassword = "$s0$40000801$eM1F+ITBb6SVFQ5QxD2jWXY8s4RGsIU+Yh4JosOewoY=$1h22/MY2cpm9Vz7//NRiXwCjffVXQWOKJ7n27vNVfP4=";
-            Assert.True(encoder.Compare("MyPassword", hashedPassword));
-
-            hashedPassword = "$s1$40000801$5ScyYcGbFmSF5P+A64cThg+c6rFtsfyxDHkWWCt97xI=$U+7EMhBXHjNHudmn/sgvX4VZ6ddoSKLkL0nDOSKYLaQ=";
             Assert.True(encoder.Compare("MyPassword", hashedPassword));
         }
 

--- a/src/Scrypt.Tests/ScryptEncoderTests.cs
+++ b/src/Scrypt.Tests/ScryptEncoderTests.cs
@@ -1,5 +1,5 @@
-﻿using Scrypt;
-using System;
+﻿using System;
+using System.Text;
 using Xunit;
 
 namespace Scrypt.Tests
@@ -55,6 +55,24 @@ namespace Scrypt.Tests
 
             hashedPassword = "$s1$40000801$5ScyYcGbFmSF5P+A64cThg+c6rFtsfyxDHkWWCt97xI=$U+7EMhBXHjNHudmn/sgvX4VZ6ddoSKLkL0nDOSKYLaQ=";
             Assert.True(encoder.Compare("MyPassword", hashedPassword));
+        }
+
+        [Theory]
+        [InlineData("", "", 16, 1, 1, 64, "77 d6 57 62 38 65 7b 20 3b 19 ca 42 c1 8a 04 97 f1 6b 48 44 e3 07 4a e8 df df fa 3f ed e2 14 42 fc d0 06 9d ed 09 48 f8 32 6a 75 3a 0f c8 1f 17 e8 d3 e0 fb 2e 0d 36 28 cf 35 e2 0c 38 d1 89 06")]
+        [InlineData("password", "NaCl", 1024, 8, 16, 64, "fd ba be 1c 9d 34 72 00 78 56 e7 19 0d 01 e9 fe 7c 6a d7 cb c8 23 78 30 e7 73 76 63 4b 37 31 62 2e af 30 d9 2e 22 a3 88 6f f1 09 27 9d 98 30 da c7 27 af b9 4a 83 ee 6d 83 60 cb df a2 cc 06 40")]
+        [InlineData("pleaseletmein", "SodiumChloride", 16384, 8, 1, 64, "70 23 bd cb 3a fd 73 48 46 1c 06 cd 81 fd 38 eb fd a8 fb ba 90 4f 8e 3e a9 b5 43 f6 54 5d a1 f2 d5 43 29 55 61 3f 0f cf 62 d4 97 05 24 2a 9a f9 e6 1e 85 dc 0d 65 1e 40 df cf 01 7b 45 57 58 87")]
+        [InlineData("pleaseletmein", "SodiumChloride", 1048576, 8, 1, 64, "21 01 cb 9b 6a 51 1a ae ad db be 09 cf 70 f8 81 ec 56 8d 57 4a 2f fd 4d ab e5 ee 98 20 ad aa 47 8e 56 fd 8f 4b a5 d0 9f fa 1c 6d 92 7c 40 f4 c3 37 30 40 49 e8 a9 52 fb cb f4 5c 6f a7 7a 41 a4")]
+        public void TestVectorsForCryptoScrypt(string password, string salt, int N, int r, int p, int dklen, string expected)
+        {
+            // These test vectors are taken from RFC 7914: https://datatracker.ietf.org/doc/html/rfc7914#section-12
+
+            var P = Encoding.UTF8.GetBytes(password);
+            var S = Encoding.UTF8.GetBytes(salt);
+
+            var actualBytes = ScryptEncoder.CryptoScrypt(P, S, N, r, p, dklen);
+            var actualString = BitConverter.ToString(actualBytes).Replace("-", " ");
+
+            Assert.Equal(expected, actualString, ignoreCase: true);
         }
     }
 }

--- a/src/Scrypt.Tests/packages.config
+++ b/src/Scrypt.Tests/packages.config
@@ -6,4 +6,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
This PR adds the [scrypt test vectors from RFC 7914](https://datatracker.ietf.org/doc/html/rfc7914#section-12) and does some other minor adjustments:
* updates the test project's target framework to 4.8
* slightly adjusts other tests
* adds the .NET Core project to the solution (this seems to have been accidentally lost with commit ca64dea)
* adds the `.vs` directory to gitignore